### PR TITLE
add whitespace to IdentityEscape

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -27,6 +27,7 @@ contributors: Jordan Harband
         IdentityEscape[UnicodeMode] ::
           [+UnicodeMode] SyntaxCharacter
           [+UnicodeMode] `/` <ins>`,` `-` `=` `<` `>` `/` `#` `&` `!` `%` `:` `;` `@` `~` `'` `"`</ins>
+          <ins>[+UnicodeMode] WhiteSpace</ins>
           [~UnicodeMode] SourceCharacter but not UnicodeIDContinue
 
         DecimalEscape ::


### PR DESCRIPTION
Just noticed these were missing. Haven't rendered this to check it works though.

We'll need to do this anyway for x-mode regexps.