### PR TITLE
Address feedback from plenary

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -52,12 +52,14 @@ contributors:
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a string representing a |Pattern| for matching _c_. If _c_ is white space or an ASCII punctuator, the returned value is an escape sequence (corresponding with |HexEscapeSequence| if possible, or otherwise with |RegExpUnicodeEscapeSequence|). Otherwise, the returned value is a string representation of _c_ itself.</dd>
+          <dd>It returns a string representing a |Pattern| for matching _c_. If _c_ is white space or an ASCII punctuator, the returned value is an escape sequence. Otherwise, the returned value is a string representation of _c_ itself.</dd>
         </dl>
 
         <emu-alg>
-          1. Let _punctuators_ be the string-concatenation of *"(){}[]|,.?\*+-^$=<>/#&!%:;@~'`"*, the code unit 0x0022 (QUOTATION MARK), and the code unit 0x005C (REVERSE SOLIDUS).
-          1. Let _toEscape_ be StringToCodePoints(_punctuators_).
+          1. If _c_ is matched by |SyntaxCharacter| or _c_ is U+002F (SOLIDUS), then
+            1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and UTF16EncodeCodePoint(_c_).
+          1. Let _otherPunctuators_ be the string-concatenation of *",-=<>#&!%:;@~'`"* and the code unit 0x0022 (QUOTATION MARK).
+          1. Let _toEscape_ be StringToCodePoints(_otherPunctuators_).
           1. If _toEscape_ contains _c_ or _c_ is matched by |WhiteSpace|, then
             1. If _c_ ≤ 0xFF, then
               1. Let _hex_ be Number::toString(𝔽(_c_), 16).

--- a/spec.emu
+++ b/spec.emu
@@ -60,7 +60,7 @@ contributors:
             1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and UTF16EncodeCodePoint(_c_).
           1. Let _otherPunctuators_ be the string-concatenation of *",-=<>#&!%:;@~'`"* and the code unit 0x0022 (QUOTATION MARK).
           1. Let _toEscape_ be StringToCodePoints(_otherPunctuators_).
-          1. If _toEscape_ contains _c_ or _c_ is matched by |WhiteSpace|, then
+          1. If _toEscape_ contains _c_ or _c_ is matched by |WhiteSpace| or |LineTerminator|, then
             1. If _c_ ≤ 0xFF, then
               1. Let _hex_ be Number::toString(𝔽(_c_), 16).
               1. Return the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), *"x"*, and StringPad(_hex_, 2, *"0"*, ~start~).

--- a/spec.emu
+++ b/spec.emu
@@ -58,6 +58,8 @@ contributors:
         <emu-alg>
           1. If _c_ is matched by |SyntaxCharacter| or _c_ is U+002F (SOLIDUS), then
             1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and UTF16EncodeCodePoint(_c_).
+          1. Else if _c_ is the code point listed in some cell of the “Code Point” column of <emu-xref href="#table-controlescape-code-point-values"></emu-xref>, then
+            1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and the string in the “ControlEscape” column of the row whose “Code Point” column contains _c_.
           1. Let _otherPunctuators_ be the string-concatenation of *",-=<>#&!%:;@~'`"* and the code unit 0x0022 (QUOTATION MARK).
           1. Let _toEscape_ be StringToCodePoints(_otherPunctuators_).
           1. If _toEscape_ contains _c_ or _c_ is matched by |WhiteSpace| or |LineTerminator|, then

--- a/spec.emu
+++ b/spec.emu
@@ -31,9 +31,11 @@ contributors:
           1. Let _escaped_ be the empty String.
           1. Let _cpList_ be StringToCodePoints(_S_).
           1. For each code point _c_ in _cpList_, do
-            1. If _escaped_ is the empty String and _c_ is matched by |DecimalDigit|, then
-              1. NOTE: Escaping a leading digit ensures that output corresponds with pattern text which may be used after a `\0` character escape or a |DecimalEscape| such as `\1` and still match _S_ rather than be interpreted as an extension of the preceding escape sequence.
-              1. Set _escaped_ to the string-concatenation of _escaped_, the code unit 0x005C (REVERSE SOLIDUS), *"x3"*, and the code unit whose numeric value is the numeric value of _c_.
+            1. If _escaped_ is the empty String, and _c_ is matched by |DecimalDigit| or |AsciiLetter|, then
+              1. NOTE: Escaping a leading digit ensures that output corresponds with pattern text which may be used after a `\0` character escape or a |DecimalEscape| such as `\1` and still match _S_ rather than be interpreted as an extension of the preceding escape sequence. Escaping a leading ASCII letter does the same for the context after `\c`.
+              1. Let _hex_ be Number::toString(𝔽(_c_), 16).
+              1. Assert: The length of _hex_ is 2.
+              1. Set _escaped_ to the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), *"x"*, and _hex_.
             1. Else,
               1. Set _escaped_ to the string-concatenation of _escaped_ and EncodeForRegExpEscape(_c_).
           1. Return _escaped_.

--- a/spec.emu
+++ b/spec.emu
@@ -62,7 +62,7 @@ contributors:
             1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and the string in the “ControlEscape” column of the row whose “Code Point” column contains _c_.
           1. Let _otherPunctuators_ be the string-concatenation of *",-=<>#&!%:;@~'`"* and the code unit 0x0022 (QUOTATION MARK).
           1. Let _toEscape_ be StringToCodePoints(_otherPunctuators_).
-          1. If _toEscape_ contains _c_ or _c_ is matched by |WhiteSpace| or |LineTerminator|, then
+          1. If _toEscape_ contains _c_, _c_ is matched by |WhiteSpace| or |LineTerminator|, or _c_ has the same numeric value as a leading surrogate or trailing surrogate, then
             1. If _c_ ≤ 0xFF, then
               1. Let _hex_ be Number::toString(𝔽(_c_), 16).
               1. Return the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), *"x"*, and StringPad(_hex_, 2, *"0"*, ~start~).


### PR DESCRIPTION
Commits should be reviewed individually. Summary:

- use `\$` etc where possibly; this is not possible for all punctuators, but it is for some
- also escape line terminators; this was just an oversight on my part
- use `\n` etc where possible
- if given a lone surrogate, escape it, so that if there is someday a non-BMP whitespace character, and we get `x`-mode RegExps, and someone writes `new RegExp(RegExp.escape('\uHEAD') + RegExp.escape('\uTAIL'), 'x')` where `\uHEAD\uTAIL` encodes that non-BMP whitespace character, the resulting RegExp will match the character instead of being interpreted as whitespace and therefore (in `x`-mode) ignored
- hex-escape ASCII letters at the start of the string so that `new RegExp('\c' + RegExp.escape('Z'))` will either be an error (in `u`- or `v`-mode RegExps) or match the string `'\\cZ'` (in other RegExps); this also has the effect that the result cannot combine with a preceding `\x` or `\u` when the first character is `A-F` or `a-f`. Fixes #66.